### PR TITLE
Update GNOME runtime to version 46

### DIFF
--- a/org.flozz.calcleaner.yml
+++ b/org.flozz.calcleaner.yml
@@ -1,6 +1,6 @@
 app-id: org.flozz.calcleaner
 runtime: org.gnome.Platform
-runtime-version: "45"
+runtime-version: "46"
 sdk: org.gnome.Sdk
 command: calcleaner
 finish-args:


### PR DESCRIPTION
GNOME runtime version 45 has reached EOL.